### PR TITLE
Backport base template from layout updates in jfmcbrayer/clubeleven

### DIFF
--- a/templates/base_template.html
+++ b/templates/base_template.html
@@ -1,132 +1,123 @@
+<!DOCTYPE html>
 <html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>{% block title %}Club Eleven {% endblock %}</title>
+        <link rel="stylesheet" href="/static/css/bulma.css">
+        <link rel="stylesheet" href="/static/css/fork-awesome.css">
+        <link rel="stylesheet"
+              href="https://cdn.jsdelivr.net/npm/fork-awesome@1.0.11/css/fork-awesome.min.css"
+              integrity="sha256-MGU/JUq/40CFrfxjXb5pZjpoZmxiP2KuICN5ElLFNd8="
+              crossorigin="anonymous">
+        <link rel="stylesheet"
+              href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.6.1/css/bulma.min.css">
+        <link rel="stylesheet" media="screen" href="../stylesheets/scratchpad.css">
+    </head>
+    <body>
+        <nav class="navbar" >
+            <!-- Top nav -->
+            {% block nav %}
+            <div class="navbar-brand">
+                <a class="navbar-item">
+                    <img src="https://bulma.io/images/placeholders/128x128.png" alt="Aardwolf">
+                </a>
+                <div class="navbar-burger burger" data-target="navbar_menu_hero_a">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </div>
+            </div>
+            </div>
+            <div id="navbar_menu_hero_a" class="navbar-menu">
+                <div class="navbar-start" >
+                    <div class="navbar-item">
+                        <div class="field is-grouped">
+                            <p class="control is-expanded">
+                                <input class="input  is-small" type="text" placeholder="Find a repository">
+                            </p>
+                            <p class="control">
+                                <a class="button is-info is-small">
+                                    Search
+                                </a>
+                            </p>
+                        </div>
+                    </div>
+                <div class="navbar-end">
+                    <a class="navbar-item is-active">
+                        Home
+                    </a>
+                    <a class="navbar-item">
+                        Examples
+                    </a>
+                    <a class="navbar-item">
+                        Documentation
+                    </a>
+                    <span class="navbar-item">
+                        <a class="button is-primary is-inverted">
+                            <span class="icon">
+                                <i class="fa fa-github"></i>
+                            </span>
+                            <span>Download</span>
+                        </a>
+                    </span>
+                </div>
+            </div>
+            {% endblock %}
+        </nav>
 
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Aardwolf - Main</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.6.1/css/bulma.min.css">
-  <!-- This is a hacky CSS that really needs to be fixed/replaced. I'm just putting it here to see if I can improve the styling until proper Bulma implementation -->
-  <link rel="stylesheet" media="screen" href="../stylesheets/scratchpad.css">
-</head>
+        <div class="columns is-mobile">
+            <div class="column is-3" style="padding-left: 1em; background-color: aliceblue">
+                <aside class="menu">
+                    {% block menu %}
+                    <a class="fa fa-user-circle-o"> BanjoFox</a>
+                    <ul class="menu-list">
+                        <li><a class="fa fa-newspaper-o" aria-hidden="true"> News Feed</a></li>
+                        <li><a class="fa fa-envelope" aria-hidden="true"> Messages</a></li>
+                    </ul>
+                    <p class="menu-label">
+                        <span class="fa fa-star" aria-hidden="true"> Shortcuts</span>
+                    </p>
+                    <ul class="menu-list">
+                        <li><a class="fa fa-calendar" aria-hidden="true"> Calendar</a></li>
+                        <li><a class="fa fa-users" aria-hidden="true"> Groups</a></li>
+                        <li><a class="fa fa-list" aria-hidden="true"> Lists</a></li>
+                        <li><a class="fa fa-picture-o" aria-hidden="true"> Photos</a></li>
+                        <li><a class="fa fa-bookmark" aria-hidden="true"> Favorites</a></li>
+                        <li><a class="fa fa-cloud" aria-hidden="true"> Weather</a></li>
+                    </ul>
+                    <p class="menu-label">
+                        <span class="fa fa-lightbulb-o" aria-hidden="true"> Make Something!</span>
+                    </p>
+                    <ul class="menu-list">
+                        <li><a class="fa fa-calendar-plus-o" aria-hidden="true"> New Event</a></li>
+                        <li><a class="fa fa-users" aria-hidden="true"> New Group</a></li>
+                    </ul>
+                    {% endblock %}
+                </aside>
+            </div>
 
-<body>
-
-  <nav class="navbar" style="padding-top: 2em; background-color: cadetblue">
-    <!-- Top nav -->
-    <div class="container">
-      <div class="navbar-brand">
-        <a class="navbar-item">
-          <img src="https://bulma.io/images/placeholders/128x128.png" alt="Aardwolf">
-        </a>
-        <span class="navbar-burger burger" data-target="navbar_menu_hero_a">
-			<span></span>
-        <span></span>
-        <span></span>
-        </span>
-      </div>
-      <div class="container" style="position: bottom">
-        <!-- I don't think this is really needed for the "Search" bar but it expands to fit LOL -->
-        <div class="field is-grouped">
-          <p class="control is-expanded">
-            <input class="input  is-small" type="text" placeholder="Find a repository">
-          </p>
-          <p class="control">
-            <a class="button is-info is-small">
-				  Search
-				</a>
-          </p>
+            <div class="column">
+                <section class="section">
+                    {% block content %}
+                    <p> Primary feed will go here.  This is the "sample_converstation" from home_demo.html.</p>
+                    {% endblock %}
+                </section>
+            </div>
         </div>
-      </div>
-      <div id="navbar_menu_hero_a" class="navbar-menu">
-        <div class="navbar-end">
-          <a class="navbar-item is-active">
-			  Home
-			</a>
-          <a class="navbar-item">
-			  Examples
-			</a>
-          <a class="navbar-item">
-			  Documentation
-			</a>
-          <span class="navbar-item">
-			  <a class="button is-primary is-inverted">
-				<span class="icon">
-				  <i class="fa fa-github"></i>
-				</span>
-          <span>Download</span>
-          </a>
-          </span>
-        </div>
-      </div>
-    </div>
-  </nav>
+        <footer class="footer">
+            <div class="container">
+                <div class="content has-text-centered">
+                    <a href="termsofservice.html" class="footer_box">Terms of Service</a>
+                    <span class="vertical_line" />
+                    <span class="footer_box">Copyright - 2017</span>
+                    <span class="vertical_line" />
+                    <a href="https://github.com/BanjoFox/aardwolf" class="footer_box">Check us out on <i class="fa fa-lg fa-github"></i></a>
+                    <span class="vertical_line" />
+                    <a href="https://www.patreon.com/banjofox" class="footer_box">Buy Banjo a <span class="fa fa-beer"aria-hidden="true"></span></a>
+                </div>
+            </div>
+        </footer>
 
-  <div class="columns is-mobile">
-    <div class="columns is-3" style="padding-left: 1em; background-color: aliceblue">
-      <section class="section">
-        <!-- Does this need to be in a <div class="container> ?? -->
-        <!-- For now I would say no, because making it a container brings it to left-center -->
-        <aside class="menu">
-          <a class="fa fa-user-circle-o"> BanjoFox</a>
-          <ul class="menu-list">
-            <li><a class="fa fa-newspaper-o" aria-hidden="true"> News Feed</a></li>
-            <li><a class="fa fa-envelope" aria-hidden="true"> Messages</a></li>
-          </ul>
-          <p class="menu-label">
-            <span class="fa fa-star" aria-hidden="true"> Shortcuts</span>
-          </p>
-          <ul class="menu-list">
-            <li><a class="fa fa-calendar" aria-hidden="true"> Calendar</a></li>
-            <li><a class="fa fa-users" aria-hidden="true"> Groups</a></li>
-            <li><a class="fa fa-list" aria-hidden="true"> Lists</a></li>
-            <li><a class="fa fa-picture-o" aria-hidden="true"> Photos</a></li>
-            <li><a class="fa fa-bookmark" aria-hidden="true"> Favorites</a></li>
-            <li><a class="fa fa-cloud" aria-hidden="true"> Weather</a></li>
-          </ul>
-          <p class="menu-label">
-            <span class="fa fa-lightbulb-o" aria-hidden="true"> Make Something!</span>
-          </p>
-          <ul class="menu-list">
-            <li><a class="fa fa-calendar-plus-o" aria-hidden="true"> New Event</a></li>
-            <li><a class="fa fa-users" aria-hidden="true"> New Group</a></li>
-        </aside>
-      </section>
-    </div>
-    <div class="columns">
-      <section class="section">
-        <div class="container">
-		
-          <!-- Begin new post -->
-          <article class="media">
-			<p> This is the "new_post" text area from home_demo.html.</p>
-          </article>
-          <!-- End new post -->
-
-          <!-- Begin sample conversation -->
-		  <article class="media">
-			<p> Primary feed will go here.  This is the "sample_converstation" from home_demo.html.</p>
-          </article>
-
-          <!-- End sample conversation -->
-
-        </div>
-      </section>
-    </div>
-  </div>
-</body>
-<footer class="footer">
-  <div class="container">
-    <div class="content has-text-centered">
-      <a href="termsofservice.html" class="footer_box">Terms of Service</a>
-      <span class="vertical_line" />
-      <span class="footer_box">Copyright - 2017</span>
-      <span class="vertical_line" />
-      <a href="https://github.com/BanjoFox/aardwolf" class="footer_box">Check us out on <i class="fa fa-lg fa-github"></i></a>
-      <span class="vertical_line" />
-      <a href="https://www.patreon.com/banjofox" class="footer_box">Buy Banjo a <span class="fa fa-beer"aria-hidden="true"></span></a>
-    </div>
-  </div>
-</footer>
-
+    </body>
 </html>

--- a/web/stylesheets/scratchpad.css
+++ b/web/stylesheets/scratchpad.css
@@ -33,3 +33,8 @@ footer {
   /* top | right | bottom | left */
   padding: 4px 1em 6px 2em;
 }
+
+.navbar
+{
+    background-color: #55CCCC;
+}


### PR DESCRIPTION
This is a backport of layout fixes that I originally did in clubeleven to the
base aardwolf template.

Changes:
* Changed structure to match bulma's expectations
* Added blocks. I *believe* tera blocks are the same as django blocks, so I just
  left my original blocks in.
* Update from font-awesome to fork-awesome. Still using CDN instead of serving
  locally.